### PR TITLE
removed bushes:sugar (bushes_classic).

### DIFF
--- a/mods/plantlife_modpack/bushes_classic/cooking.lua
+++ b/mods/plantlife_modpack/bushes_classic/cooking.lua
@@ -20,6 +20,17 @@ minetest.register_craft({
 
 -- Sugar
 
+-- Use the sugar from farming redo if available
+if minetest.get_modpath("farming") and farming.mod == "redo" then
+	--[[ We really have nothing to do to use farming:sugar in the recipes
+	     because they use the generic group group:food_sugar
+	     which is added to the groups list of farming:sugar by the mod "food". 
+	--]]
+
+	--Temporary alias to replace existing bushes:sugar in the world
+	--minetest.register_alias("bushes:sugar", "farming:sugar")
+
+else
 minetest.register_craftitem(":bushes:sugar", {
     description = S("Sugar"),
     inventory_image = "bushes_sugar.png",
@@ -33,6 +44,7 @@ minetest.register_craft({
 	{ "default:papyrus", "default:papyrus" },
     },
 })
+end
 
 for i, berry in ipairs(bushes_classic.bushes) do
 	local desc = bushes_classic.bushes_descriptions[i]


### PR DESCRIPTION
Petite mise à jour pour supprimer le sucre de bushes_classic. Les recettes sont prêtes d'origine à le remplacer par celui de farming redo, grâce au mod "Food", qui ajoute un groupe générique à ce sucre.

J'ai laissé un alias en commentaire à activer temporairement pour remplacer le sucre de bushes_classic que des joueurs pourraient avoir dans leur inventaire par celui de farming redo. Je ne crois pas que ça vaille la peine de l'activer mais c'est facile de le faire au moins. Il faudrait le désactiver au bout d'un moment pour faire disparaitre les deux appellations du même sucre que ça créerait dans le crafting guide. 

Le code d'origine est délibérément laissé tel quel (non indenté) pour faciliter la mise à jour automatique de plantlife_modpack/bushes_classic sans revenir sur celle-là.
