### PR TITLE
Fixed the Soil abm.

### DIFF
--- a/mods/farming/soil.lua
+++ b/mods/farming/soil.lua
@@ -45,15 +45,19 @@ minetest.register_abm({
 		end
 
 		-- check if there is water nearby and change soil accordingly
-		if minetest.find_node_near(pos, 3, {"group:water"}) and
-			minetest.find_node_near(pos, 3, {"ignore"}) then
+		if minetest.find_node_near(pos, 3, {"group:water"}) then
 			if node.name == "farming:soil" then
 				minetest.set_node(pos, {name="farming:soil_wet"})
 			end
-		elseif node.name == "farming:soil_wet" then
-			minetest.set_node(pos, {name="farming:soil"})
-		elseif node.name == "farming:soil" then
-			minetest.set_node(pos, {name="default:dirt"})
+		else
+			-- Don't turn wet soil into dry soil or dry soil into dirt
+			-- if there are unloaded blocks nearby because they could be water.
+			if minetest.find_node_near(pos, 3, {"ignore"}) then return end
+			if node.name == "farming:soil_wet" then
+				minetest.set_node(pos, {name="farming:soil"})
+			else -- [obviously] node.name == "farming:soil" 
+				minetest.set_node(pos, {name="default:dirt"})
+			end
 		end
 	end,
 })


### PR DESCRIPTION
Les champs (farming:soil*) disparaissent sauf s'ils sont à côté d'eau et d'un bloc non chargé en mémoire.

Stratégie:
S'il y a de l'eau à proximité, ils deviennent/restent irrigués. S'il n'y a pas d'eau, on ne change rien s'il y a des blocs non chargés ("ignore") à côté des champs parce qu'eux pourraient être de l'eau. S'il n'y a pas de bloc non chargé, alors on peut les dégrader. 
